### PR TITLE
Add ssl context builder for a single cert CA file (PostgreSQL case)

### DIFF
--- a/src/less/awful/ssl.clj
+++ b/src/less/awful/ssl.clj
@@ -133,7 +133,8 @@
 
 (defn ssl-context-generator
   "Returns a function that yields SSL contexts. Takes a PKCS8 key file, a
-  certificate file, and optionally, a trusted CA certificate used to verify peers."
+  certificate file, and optionally, a trusted CA certificate used to verify peers.
+  The arity-1 body accepts a trusted CA certificate only."
   ([key-file cert-file ca-cert-file]
    (let [key-manager (key-manager (key-store key-file cert-file))
          trust-manager (trust-manager (trust-store ca-cert-file))]
@@ -159,7 +160,8 @@
 
 (defn ssl-context
   "Given a PKCS8 key file, a certificate file, and optionally, a trusted CA certificate
-  used to verify peers, returns an SSLContext."
+  used to verify peers, returns an SSLContext. The arity-1 body accepts a single trusted
+  CA certificate which is commonly used to reach databases."
   (^SSLContext [key-file cert-file ca-cert-file]
    ((ssl-context-generator key-file cert-file ca-cert-file)))
   (^SSLContext [key-file cert-file]

--- a/src/less/awful/ssl.clj
+++ b/src/less/awful/ssl.clj
@@ -128,7 +128,7 @@
             (filter (partial instance? X509KeyManager))
             first))))
   ([key-store]
-   (key-manager key-store key-store-password))  )
+   (key-manager key-store key-store-password)))
 
 
 (defn ssl-context-generator
@@ -148,15 +148,24 @@
        (doto (SSLContext/getInstance "TLSv1.2")
          (.init (into-array KeyManager [key-manager])
                 nil
+                nil)))))
+  ([ca-cert-file]
+   (let [trust-manager (trust-manager (trust-store ca-cert-file))]
+     (fn build-context []
+       (doto (SSLContext/getInstance "TLSv1.2")
+         (.init nil
+                (into-array TrustManager [trust-manager])
                 nil))))))
 
 (defn ssl-context
   "Given a PKCS8 key file, a certificate file, and optionally, a trusted CA certificate
   used to verify peers, returns an SSLContext."
-  ([key-file cert-file ca-cert-file]
+  (^SSLContext [key-file cert-file ca-cert-file]
    ((ssl-context-generator key-file cert-file ca-cert-file)))
-  ([key-file cert-file]
-   ((ssl-context-generator key-file cert-file))))
+  (^SSLContext [key-file cert-file]
+   ((ssl-context-generator key-file cert-file)))
+  (^SSLContext [ca-cert-file]
+   ((ssl-context-generator ca-cert-file))))
 
 (defn ssl-p12-context-generator
       "Returns a function that yields an SSL contexts. Takes a PKCS12 key/cert file, the
@@ -181,8 +190,7 @@
 
 (defn ssl-context->engine
   [ctx]
-  (.createSSLEngine ^SSLContext ctx)
-  )
+  (.createSSLEngine ^SSLContext ctx))
 
 (def enabled-protocols
   "An array of protocols we support."


### PR DESCRIPTION
First of all, thank you for that great library! It has helped me more times than I can remember.

I'm currently using it in PG2 (a PostgreSQL client) for SSL connections. There is a case when cloud provider shares a single cert-ca file and you need to build an instance of SSLContext out from it. At the moment, the `ssl-context` function accepts either 3 or 2 files, and I extended it with an extra 1-arify body for a cert-ca file.

I've tested it locally using this branch, SSL works:

```
(def ssl-context
  (ssl/ssl-context "/Users/ivan/Downloads/prod-ca-2021.crt"))

(def config
  {:host "aws-0-eu-central-1.pooler.supabase.com"
   :port 6543
   :user "postgres.hmtrzfggdhnofcaseomq"
   :password "......"
   :database "postgres"
   :use-ssl? true
   :ssl-context ssl-context})

(with-conn [conn config]
  (query conn "select 1"))
```

Should anything must be refactored, let me know please.
