### PR TITLE
Add a dummy ssl context and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ socket. See `core.clj/test-ssl` for an example:
 
 ## Example with a PKCS12 client certificate and org.httpkit
 
-Assume you've got a client key/certificate pair for `example.com` as a PKCS12 file `client.p12`, 
-secured with _password_. Also, you've got the Certificate Autority that was used to 
+Assume you've got a client key/certificate pair for `example.com` as a PKCS12 file `client.p12`,
+secured with _password_. Also, you've got the Certificate Autority that was used to
 sign the client certificate as `ca-cert.crt`.
 
 Then you could do (your project needs http-kit, of course):
@@ -133,6 +133,23 @@ Then you could do (your project needs http-kit, of course):
 (def req (http/request {:sslengine (ssl-context->engine (ssl-p12-context "client.p12" password "ca-cert.crt"))
                         :url "https://example.com/needs-client-cert" :as :stream}))
 ```
+
+## Dummy SSL Context
+
+In rare cases you need an SSL context which, in fact, validates nothing: nor
+server certificates nor client ones. Crafting such an `SSLContext` object always
+takes lines of code but now there is a shortcut for that. A small example:
+
+~~~clojure
+(let [ssl-context (ssl/dummy-ssl-context)
+      client (http/build-client {:ssl-context ssl-context})]
+  (http/get "https://acme.api.example.com/users/42" {:client client}))
+~~~
+
+Above, we reach the URL using a custom version of an HTTP client. This client
+won't throw an exception when missing local certificates. Of course, this
+technique should not be a common practice. Use if for tests, self-signed
+certificates, or when you really know what are you doing.
 
 ## Thanks
 

--- a/src/less/awful/ssl.clj
+++ b/src/less/awful/ssl.clj
@@ -30,6 +30,8 @@
                           X509KeyManager
                           X509TrustManager)))
 
+(set! *warn-on-reflection* true)
+
 (defmacro base64->binary [string]
   (if (try (import 'java.util.Base64)
            (catch ClassNotFoundException _))
@@ -284,3 +286,32 @@
 
     (prn :waiting-for-server)
     @server))
+
+(defn dummy-trust-manager
+  "
+  Make a dummy TrustManager that doesn't validate
+  any certificates.
+  "
+  ^X509TrustManager []
+  (reify X509TrustManager
+    (getAcceptedIssuers [_this]
+      nil)
+    (checkClientTrusted [_this _certs _auth]
+      nil)
+    (checkServerTrusted [_this _certs _auth]
+      nil)))
+
+(defn dummy-ssl-context
+  "
+  Produce a dummy SSLContext instance that doesn't
+  validate any certificates. The protocol, when not
+  specified, is TLS.
+  "
+  (^SSLContext []
+   (dummy-ssl-context "TLS"))
+
+  (^SSLContext [^String protocol]
+   (let [trust-managers (into-array TrustManager [(dummy-trust-manager)])
+         ctx (SSLContext/getInstance protocol)]
+     (.init ctx nil trust-managers nil)
+     ctx)))

--- a/test/less/awful/ssl_test.clj
+++ b/test/less/awful/ssl_test.clj
@@ -1,7 +1,8 @@
 (ns less.awful.ssl-test
   (:require [clojure.test :refer :all]
             [less.awful.ssl :as ssl])
-  (:import (java.nio.charset StandardCharsets)))
+  (:import (java.nio.charset StandardCharsets)
+           (javax.net.ssl SSLContext)))
 
 (deftest base64
   (let [test-str (apply str (repeat 4 "less-awful-ssl"))]
@@ -13,3 +14,7 @@
       (is (= test-str
              (-> (ssl/base64->binary "bGVzcy1hd2Z1bC1zc2xsZXNzLWF3ZnVsLXNzbGxlc3MtYXdmdWwtc3NsbGVzcy1hd2Z1bC1zc2w=")
                  (String. StandardCharsets/UTF_8)))))))
+
+(deftest test-ssl-dummy
+  (let [ssl-context (ssl/dummy-ssl-context)]
+    (is (instance? SSLContext ssl-context))))


### PR DESCRIPTION
Hi!

I thought this library could be a good place for storing a couple of helper functions. These two create an SSLContext instance that validates nothing. I've been using it from time to time and had to copy code from project to project. Now, can we host them here please?
